### PR TITLE
feat(staking): make staking keeper endblocker return unbonded entry

### DIFF
--- a/tests/integration/staking/keeper/delegation_test.go
+++ b/tests/integration/staking/keeper/delegation_test.go
@@ -103,7 +103,7 @@ func TestUnbondingDelegationsMaxEntries(t *testing.T) {
 
 	// mature unbonding delegations
 	ctx = ctx.WithBlockTime(completionTime)
-	_, err = f.stakingKeeper.CompleteUnbonding(ctx, addrDel, addrVal)
+	_, _, err = f.stakingKeeper.CompleteUnbonding(ctx, addrDel, addrVal)
 	assert.NilError(t, err)
 
 	newBonded = f.bankKeeper.GetBalance(ctx, f.stakingKeeper.GetBondedPool(ctx).GetAddress(), bondDenom).Amount

--- a/tests/integration/staking/keeper/unbonding_test.go
+++ b/tests/integration/staking/keeper/unbonding_test.go
@@ -403,7 +403,7 @@ func TestUnbondingDelegationOnHold1(t *testing.T) {
 
 	// PROVIDER CHAIN'S UNBONDING PERIOD ENDS - STOPPED UNBONDING CAN NOW COMPLETE
 	f.sdkCtx = f.sdkCtx.WithBlockTime(completionTime)
-	_, err = f.stakingKeeper.CompleteUnbonding(f.sdkCtx, addrDels[0], addrVals[0])
+	_, _, err = f.stakingKeeper.CompleteUnbonding(f.sdkCtx, addrDels[0], addrVals[0])
 	assert.NilError(t, err)
 
 	// Check that the unbonding was finally completed
@@ -430,7 +430,7 @@ func TestUnbondingDelegationOnHold2(t *testing.T) {
 
 	// PROVIDER CHAIN'S UNBONDING PERIOD ENDS - BUT UNBONDING CANNOT COMPLETE
 	f.sdkCtx = f.sdkCtx.WithBlockTime(completionTime)
-	_, err := f.stakingKeeper.CompleteUnbonding(f.sdkCtx, addrDels[0], addrVals[0])
+	_, _, err := f.stakingKeeper.CompleteUnbonding(f.sdkCtx, addrDels[0], addrVals[0])
 	assert.NilError(t, err)
 
 	bondedAmt3 := f.bankKeeper.GetBalance(f.sdkCtx, f.stakingKeeper.GetBondedPool(f.sdkCtx).GetAddress(), bondDenom).Amount

--- a/x/staking/keeper/abci.go
+++ b/x/staking/keeper/abci.go
@@ -18,6 +18,15 @@ func (k *Keeper) BeginBlocker(ctx context.Context) error {
 
 // EndBlocker called at every block, update validator set
 func (k *Keeper) EndBlocker(ctx context.Context) ([]abci.ValidatorUpdate, error) {
+	valUpdates, _, err := k.EndBlockerWithUnbondedEntries(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return valUpdates, nil
+}
+
+func (k Keeper) EndBlockerWithUnbondedEntries(ctx context.Context) ([]abci.ValidatorUpdate, []types.UnbondedEntry, error) {
 	defer telemetry.ModuleMeasureSince(types.ModuleName, telemetry.Now(), telemetry.MetricKeyEndBlocker)
 	return k.BlockValidatorUpdates(ctx)
 }

--- a/x/staking/keeper/val_state_change.go
+++ b/x/staking/keeper/val_state_change.go
@@ -58,6 +58,11 @@ func (k Keeper) BlockValidatorUpdates(ctx context.Context) ([]abci.ValidatorUpda
 
 		balances, err := k.CompleteUnbonding(ctx, delegatorAddress, addr)
 		if err != nil {
+			k.Logger(ctx).Error(
+				"failed to complete unbonding",
+				"error", err,
+				"val_addr", string(addr),
+				"del_addr", string(delegatorAddress))
 			continue
 		}
 
@@ -98,6 +103,12 @@ func (k Keeper) BlockValidatorUpdates(ctx context.Context) ([]abci.ValidatorUpda
 			valDstAddr,
 		)
 		if err != nil {
+			k.Logger(ctx).Error(
+				"failed to complete redelegation",
+				"error", err,
+				"val_src_addr", string(valSrcAddr),
+				"val_dst_addr", string(valDstAddr),
+				"del_addr", string(delegatorAddress))
 			continue
 		}
 

--- a/x/staking/types/delegation.go
+++ b/x/staking/types/delegation.go
@@ -384,3 +384,9 @@ func (r RedelegationResponses) String() (out string) {
 
 	return strings.TrimSpace(out)
 }
+
+type UnbondedEntry struct {
+	ValidatorAddress string
+	DelegatorAddress string
+	Amount           math.Int
+}


### PR DESCRIPTION
Make inner wrapper(`EndBlockerWithUnbondedEntries`) of staking keeper's EndBlocker to return actually unbonded entries.
Story app will use this inner wrapper to get actually unbonded entries and process withdrawal.

related issue: https://github.com/piplabs/story/issues/197