### PR TITLE
feat(evidence): disable double signing slashing during singularity

### DIFF
--- a/x/evidence/go.mod
+++ b/x/evidence/go.mod
@@ -154,3 +154,5 @@ require (
 	pgregory.net/rapid v1.1.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/cosmos/cosmos-sdk => github.com/piplabs/cosmos-sdk v0.50.8-0.20241021173134-3032e1bdd6bf

--- a/x/evidence/go.sum
+++ b/x/evidence/go.sum
@@ -143,8 +143,6 @@ github.com/cosmos/cosmos-db v1.0.2 h1:hwMjozuY1OlJs/uh6vddqnk9j7VamLv+0DBlbEXbAK
 github.com/cosmos/cosmos-db v1.0.2/go.mod h1:Z8IXcFJ9PqKK6BIsVOB3QXtkKoqUOp1vRvPT39kOXEA=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5 h1:eNcayDLpip+zVLRLYafhzLvQlSmyab+RC5W7ZfmxJLA=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5/go.mod h1:hQGLpiIUloJBMdQMMWb/4wRApmI9hjHH05nefC0Ojec=
-github.com/cosmos/cosmos-sdk v0.50.6 h1:efR3MsvMHX5sxS3be+hOobGk87IzlZbSpsI2x/Vw3hk=
-github.com/cosmos/cosmos-sdk v0.50.6/go.mod h1:lVkRY6cdMJ0fG3gp8y4hFrsKZqF4z7y0M2UXFb9Yt40=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
 github.com/cosmos/gogogateway v1.2.0 h1:Ae/OivNhp8DqBi/sh2A8a1D0y638GpL3tkmLQAiKxTE=
@@ -575,6 +573,8 @@ github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
+github.com/piplabs/cosmos-sdk v0.50.8-0.20241021173134-3032e1bdd6bf h1:SRT51TtdhuluqhQANrKP9ySQefV+XOwXzIeu8k3ewlY=
+github.com/piplabs/cosmos-sdk v0.50.8-0.20241021173134-3032e1bdd6bf/go.mod h1:84xDDJEHttRT7NDGwBaUOLVOMN0JNE9x7NbsYIxXs1s=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/x/evidence/keeper/infraction.go
+++ b/x/evidence/keeper/infraction.go
@@ -27,6 +27,17 @@ import (
 func (k Keeper) handleEquivocationEvidence(ctx context.Context, evidence *types.Equivocation) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	logger := k.Logger(ctx)
+
+	singularityHeight, err := k.slashingKeeper.SingularityHeight(ctx)
+	if err != nil {
+		return err
+	}
+
+	if sdkCtx.BlockHeight() < int64(singularityHeight) {
+		logger.Debug("skip handling evidence before singularity")
+		return nil
+	}
+
 	consAddr := evidence.GetConsensusAddress(k.stakingKeeper.ConsensusAddressCodec())
 
 	validator, err := k.stakingKeeper.ValidatorByConsAddr(ctx, consAddr)

--- a/x/evidence/types/expected_keepers.go
+++ b/x/evidence/types/expected_keepers.go
@@ -34,6 +34,9 @@ type (
 		SlashFractionDoubleSign(context.Context) (math.LegacyDec, error)
 		Jail(context.Context, sdk.ConsAddress) error
 		JailUntil(context.Context, sdk.ConsAddress, time.Time) error
+
+		// For Story
+		SingularityHeight(ctx context.Context) (uint64, error)
 	}
 
 	// AccountKeeper define the account keeper interface contracted needed by the evidence module

--- a/x/slashing/keeper/infractions.go
+++ b/x/slashing/keeper/infractions.go
@@ -109,13 +109,13 @@ func (k Keeper) HandleValidatorSignature(ctx context.Context, addr cryptotypes.A
 	minHeight := signInfo.StartHeight + signedBlocksWindow
 	maxMissed := signedBlocksWindow - minSignedPerWindow
 
-	params, err := k.GetParams(ctx)
+	singularityHeight, err := k.SingularityHeight(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to get params")
 	}
 
 	// if we are past the minimum height and the validator has missed too many blocks, punish them
-	if height > int64(params.SingularityHeight) && height > minHeight && signInfo.MissedBlocksCounter > maxMissed {
+	if height > int64(singularityHeight) && height > minHeight && signInfo.MissedBlocksCounter > maxMissed {
 		validator, err := k.sk.ValidatorByConsAddr(ctx, consAddr)
 		if err != nil {
 			return err
@@ -175,7 +175,7 @@ func (k Keeper) HandleValidatorSignature(ctx context.Context, addr cryptotypes.A
 				"slashed", slashFractionDowntime.String(),
 				"jailed_until", signInfo.JailedUntil,
 			)
-		} else if height == int64(params.SingularityHeight) {
+		} else if height == int64(singularityHeight) {
 			// reset the counter & bitmap so that the validator won't be
 			// immediately slashed after singularity.
 			signInfo.MissedBlocksCounter = 0

--- a/x/slashing/keeper/params.go
+++ b/x/slashing/keeper/params.go
@@ -48,6 +48,11 @@ func (k Keeper) SlashFractionDowntime(ctx context.Context) (sdkmath.LegacyDec, e
 	return params.SlashFractionDowntime, err
 }
 
+func (k Keeper) SingularityHeight(ctx context.Context) (uint64, error) {
+	params, err := k.GetParams(ctx)
+	return params.SingularityHeight, err
+}
+
 // GetParams returns the current x/slashing module parameters.
 func (k Keeper) GetParams(ctx context.Context) (params types.Params, err error) {
 	store := k.storeService.OpenKVStore(ctx)


### PR DESCRIPTION
Based on #17.
Disabled slashing of double signing during the singularity.