### PR TITLE
fix(slashing): reset missed block counter at singularity block

### DIFF
--- a/x/slashing/keeper/infractions.go
+++ b/x/slashing/keeper/infractions.go
@@ -115,77 +115,85 @@ func (k Keeper) HandleValidatorSignature(ctx context.Context, addr cryptotypes.A
 	}
 
 	// if we are past the minimum height and the validator has missed too many blocks, punish them
-	if height > int64(singularityHeight) && height > minHeight && signInfo.MissedBlocksCounter > maxMissed {
-		validator, err := k.sk.ValidatorByConsAddr(ctx, consAddr)
-		if err != nil {
-			return err
-		}
-		if validator != nil && !validator.IsJailed() {
-			// Downtime confirmed: slash and jail the validator
-			// We need to retrieve the stake distribution which signed the block, so we subtract ValidatorUpdateDelay from the evidence height,
-			// and subtract an additional 1 since this is the LastCommit.
-			// Note that this *can* result in a negative "distributionHeight" up to -ValidatorUpdateDelay-1,
-			// i.e. at the end of the pre-genesis block (none) = at the beginning of the genesis block.
-			// That's fine since this is just used to filter unbonding delegations & redelegations.
-			distributionHeight := height - sdk.ValidatorUpdateDelay - 1
-
-			slashFractionDowntime, err := k.SlashFractionDowntime(ctx)
-			if err != nil {
-				return err
-			}
-
-			coinsBurned, err := k.sk.SlashWithInfractionReason(ctx, consAddr, distributionHeight, power, slashFractionDowntime, stakingtypes.Infraction_INFRACTION_DOWNTIME)
-			if err != nil {
-				return err
-			}
-
-			sdkCtx.EventManager().EmitEvent(
-				sdk.NewEvent(
-					types.EventTypeSlash,
-					sdk.NewAttribute(types.AttributeKeyAddress, consAddr.String()),
-					sdk.NewAttribute(types.AttributeKeyPower, fmt.Sprintf("%d", power)),
-					sdk.NewAttribute(types.AttributeKeyReason, types.AttributeValueMissingSignature),
-					sdk.NewAttribute(types.AttributeKeyJailed, consAddr.String()),
-					sdk.NewAttribute(types.AttributeKeyBurnedCoins, coinsBurned.String()),
-				),
-			)
-			k.sk.Jail(sdkCtx, consAddr)
-
-			downtimeJailDur, err := k.DowntimeJailDuration(ctx)
-			if err != nil {
-				return err
-			}
-			signInfo.JailedUntil = sdkCtx.BlockHeader().Time.Add(downtimeJailDur)
-
-			// We need to reset the counter & bitmap so that the validator won't be
-			// immediately slashed for downtime upon re-bonding.
-			signInfo.MissedBlocksCounter = 0
-			signInfo.IndexOffset = 0
-			err = k.DeleteMissedBlockBitmap(ctx, consAddr)
-			if err != nil {
-				return err
-			}
-
-			logger.Info(
-				"slashing and jailing validator due to liveness fault",
-				"height", height,
-				"validator", consAddr.String(),
-				"min_height", minHeight,
-				"threshold", minSignedPerWindow,
-				"slashed", slashFractionDowntime.String(),
-				"jailed_until", signInfo.JailedUntil,
-			)
-		} else if height == int64(singularityHeight) {
+	if height >= int64(singularityHeight) && height > minHeight && signInfo.MissedBlocksCounter > maxMissed {
+		if height == int64(singularityHeight) {
 			// reset the counter & bitmap so that the validator won't be
 			// immediately slashed after singularity.
+			logger.Info("reset missed block counter and bitmap after the singularity")
+
 			signInfo.MissedBlocksCounter = 0
 			signInfo.IndexOffset = 0
+
+			if err = k.DeleteMissedBlockBitmap(ctx, consAddr); err != nil {
+				return err
+			}
 		} else {
-			// validator was (a) not found or (b) already jailed so we do not slash
-			logger.Info(
-				"validator would have been slashed for downtime, but was either not found in store or already jailed",
-				"validator", consAddr.String(),
-			)
+			validator, err := k.sk.ValidatorByConsAddr(ctx, consAddr)
+			if err != nil {
+				return err
+			}
+			if validator != nil && !validator.IsJailed() {
+				// Downtime confirmed: slash and jail the validator
+				// We need to retrieve the stake distribution which signed the block, so we subtract ValidatorUpdateDelay from the evidence height,
+				// and subtract an additional 1 since this is the LastCommit.
+				// Note that this *can* result in a negative "distributionHeight" up to -ValidatorUpdateDelay-1,
+				// i.e. at the end of the pre-genesis block (none) = at the beginning of the genesis block.
+				// That's fine since this is just used to filter unbonding delegations & redelegations.
+				distributionHeight := height - sdk.ValidatorUpdateDelay - 1
+
+				slashFractionDowntime, err := k.SlashFractionDowntime(ctx)
+				if err != nil {
+					return err
+				}
+
+				coinsBurned, err := k.sk.SlashWithInfractionReason(ctx, consAddr, distributionHeight, power, slashFractionDowntime, stakingtypes.Infraction_INFRACTION_DOWNTIME)
+				if err != nil {
+					return err
+				}
+
+				sdkCtx.EventManager().EmitEvent(
+					sdk.NewEvent(
+						types.EventTypeSlash,
+						sdk.NewAttribute(types.AttributeKeyAddress, consAddr.String()),
+						sdk.NewAttribute(types.AttributeKeyPower, fmt.Sprintf("%d", power)),
+						sdk.NewAttribute(types.AttributeKeyReason, types.AttributeValueMissingSignature),
+						sdk.NewAttribute(types.AttributeKeyJailed, consAddr.String()),
+						sdk.NewAttribute(types.AttributeKeyBurnedCoins, coinsBurned.String()),
+					),
+				)
+				k.sk.Jail(sdkCtx, consAddr)
+
+				downtimeJailDur, err := k.DowntimeJailDuration(ctx)
+				if err != nil {
+					return err
+				}
+				signInfo.JailedUntil = sdkCtx.BlockHeader().Time.Add(downtimeJailDur)
+
+				// We need to reset the counter & bitmap so that the validator won't be
+				// immediately slashed for downtime upon re-bonding.
+				signInfo.MissedBlocksCounter = 0
+				signInfo.IndexOffset = 0
+				err = k.DeleteMissedBlockBitmap(ctx, consAddr)
+				if err != nil {
+					return err
+				}
+
+				logger.Info(
+					"slashing and jailing validator due to liveness fault",
+					"height", height,
+					"validator", consAddr.String(),
+					"min_height", minHeight,
+					"threshold", minSignedPerWindow,
+					"slashed", slashFractionDowntime.String(),
+					"jailed_until", signInfo.JailedUntil,
+				)
+			} else {
+				// validator was (a) not found or (b) already jailed so we do not slash
+				logger.Info(
+					"validator would have been slashed for downtime, but was either not found in store or already jailed",
+					"validator", consAddr.String(),
+				)
+			}
 		}
 	}
 


### PR DESCRIPTION
The logic for resetting missed block counter and index was in the wrong place.
This makes double-signed validator to be jailed and tombstoned during the singularity.
Fix this issue by moving to correct place.